### PR TITLE
Fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@
 
 
 # End of https://www.gitignore.io/api/go,visualstudiocode
+
+api-key


### PR DESCRIPTION
The `.gitignore` was a directory which contained a `.gitignore` file for some reason. Let's sort that out. Also storing the API key locally, so add that file to the ignore too.